### PR TITLE
chore(deps): only check /apps/web directory with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directory: "/"
+    directory: "/apps/web"
     schedule:
       interval: "weekly"
     reviewers:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated our dependency monitoring configuration to focus solely on the web application area, ensuring more precise and efficient update checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->