### PR TITLE
fix: links with vars in loop not getting variable value

### DIFF
--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maily-to/render",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": false,
   "description": "A transformer that converts Maily content into HTML email templates.",
   "sideEffects": false,

--- a/packages/render/src/maily.tsx
+++ b/packages/render/src/maily.tsx
@@ -1560,7 +1560,7 @@ export class Maily {
     const measuredWidth = Math.round(remainingWidth / autoWidthColumns.length);
 
     const columnCount = content.filter((c) => c.type === 'column').length;
-    const gap = node.attrs?.gap || DEFAULT_COLUMNS_GAP;
+    const gap = node.attrs?.gap ?? DEFAULT_COLUMNS_GAP;
 
     return [
       {

--- a/packages/render/src/maily.tsx
+++ b/packages/render/src/maily.tsx
@@ -673,7 +673,7 @@ export class Maily {
         const type = mark.type;
         if (type in this) {
           // @ts-expect-error - `this` is not assignable to type 'never'
-          return this[type]?.(mark, acc, options) as ReactElement
+          return this[type]?.(mark, acc, options) as ReactElement;
         }
 
         throw new Error(`Mark type "${type}" is not supported.`);

--- a/packages/render/src/maily.tsx
+++ b/packages/render/src/maily.tsx
@@ -673,7 +673,7 @@ export class Maily {
         const type = mark.type;
         if (type in this) {
           // @ts-expect-error - `this` is not assignable to type 'never'
-          return this[type]?.(mark, acc) as ReactElement;
+          return this[type]?.(mark, acc, options) as ReactElement
         }
 
         throw new Error(`Mark type "${type}" is not supported.`);


### PR DESCRIPTION
Fixes a bug where links in loops which use a variable for the `href` do not get their variable resolved to the correct value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved rendering consistency to better respect layout settings, ensuring column gaps are applied accurately. No visible changes to user-facing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->